### PR TITLE
Add has_member function to test if a tag is present among subnodes.

### DIFF
--- a/lib/ezxmlm.ml
+++ b/lib/ezxmlm.ml
@@ -125,6 +125,11 @@ let member_with_attr tag nodes =
   match members_with_attr tag nodes with
   | [] -> raise (Tag_not_found tag)
   | hd::_ -> hd
+  
+let has_member tag nodes =
+    match members_with_attr tag nodes with
+  | [] -> false
+  | hd::_ -> true
 
 let members tag nodes =
   List.map snd (members_with_attr tag nodes)

--- a/lib/ezxmlm.mli
+++ b/lib/ezxmlm.mli
@@ -127,6 +127,10 @@ val member_with_attr : string -> nodes -> Xmlm.attribute list * nodes
     [member_with_attr] function instead *)
 val member : string -> nodes -> nodes
 
+(** [has_member tag subnodes] returns true if the given  [tag] name is
+    present among the subnodes and false if it can't find it. *)
+val has_member : string -> nodes -> bool
+
 (** Traverses XML nodes and applies [f] to any tags that match the [tag] parameter.
     The result of the transformations is returned as a new set of nodes. *)
 val filter_map : tag:string -> f:(Xmlm.attribute list -> nodes -> nodes) -> nodes -> nodes


### PR DESCRIPTION
I have added a function to test if a tag is present among subnodes, which I found quite useful when filtering nodes depending of a precise child being present.
