### PR TITLE
New submodule Exceptionless to use options rather than exceptions.

### DIFF
--- a/lib/ezxmlm.ml
+++ b/lib/ezxmlm.ml
@@ -127,9 +127,9 @@ let member_with_attr tag nodes =
   | hd::_ -> hd
   
 let has_member tag nodes =
-    match members_with_attr tag nodes with
-  | [] -> false
-  | hd::_ -> true
+  match members_with_attr tag nodes with
+    | [] -> false
+    | hd::_ -> true
 
 let members tag nodes =
   List.map snd (members_with_attr tag nodes)
@@ -154,3 +154,32 @@ let data_to_string nodes =
     | _ -> ()
   ) nodes;
   Buffer.contents buf
+
+
+module Exceptionless =
+struct
+  let filter_attr attr value al  =
+    try Some (filter_attr attr value al)
+    with Not_found -> None
+
+  let get_attr k attrs = 
+    try Some(get_attr k attrs)
+    with Not_found -> None
+
+  let pick_tag tag cl v nodes = 
+    try Some(pick_tag tag cl v nodes)
+    with Not_found -> None
+
+  let hd nodes = 
+    try Some(hd nodes)
+    with Not_found -> None
+
+  let member_with_attr tag nodes =
+    try Some(member_with_attr tag nodes)
+    with Tag_not_found _ -> None
+
+  let member tag nodes =
+    try Some(member tag nodes)
+    with Tag_not_found _ -> None
+      
+end

--- a/lib/ezxmlm.mli
+++ b/lib/ezxmlm.mli
@@ -138,3 +138,19 @@ val filter_map : tag:string -> f:(Xmlm.attribute list -> nodes -> nodes) -> node
 (** Traverses XML nodes and applies [f] to any tags that match the [tag] parameter. *)
 val filter_iter : tag:string -> f:(Xmlm.attribute list -> nodes -> unit) -> nodes -> unit
 
+(** Operations on XML without exceptions *)
+module  Exceptionless : sig
+
+  val filter_attr : string -> string ->   (Xmlm.attribute list * nodes) list ->  (Xmlm.attribute list * nodes) option
+    
+  val get_attr : string -> Xmlm.attribute list ->  string option
+    
+  val pick_tag : string -> string -> string -> nodes -> node option
+    
+  val hd : nodes -> node option
+    
+  val member_with_attr : string -> nodes -> (Xmlm.attribute list * nodes) option
+    
+  val member : string -> nodes -> nodes option
+end
+  


### PR DESCRIPTION
I have added an ExceptionLess module (purpose similar to http://ocaml-batteries-team.github.io/batteries-included/hdoc2/BatList.Exceptionless.html for example) with the same functions as in the lib, but that return an `'a option` so that they return `None` instead of raising an exception if they do not find a node for instance.

So, to use these functions, one must do:

``` ocaml
open Ezxmlm.ExceptionLess
```

which will overwrite the versions of these functions that use exceptions.
