### PR TITLE
to_string, to_channel: add option to output XML declaration

### DIFF
--- a/lib/ezxmlm.ml
+++ b/lib/ezxmlm.ml
@@ -43,20 +43,20 @@ let to_output o t =
   | `Data d -> `Data d in
   Xmlm.output_doc_tree frag o t
 
-let write_document mode dtd doc =
-  let o = Xmlm.make_output ~decl:false mode in
+let write_document mode ?(decl=false) dtd doc =
+  let o = Xmlm.make_output ~decl mode in
   match doc with
   | [] -> ()
   | hd::tl ->
      to_output o (dtd, hd);
      List.iter (fun t -> to_output o (None, t)) tl
 
-let to_channel chan dtd doc =
-  write_document (`Channel chan) dtd doc
+let to_channel chan ?(decl=false) dtd doc =
+  write_document (`Channel chan) ~decl dtd doc
 
-let to_string ?dtd doc =
+let to_string ?(decl=false) ?dtd doc =
   let buf = Buffer.create 512 in
-  write_document (`Buffer buf) dtd doc;
+  write_document (`Buffer buf) ~decl dtd doc;
   Buffer.contents buf
 
 let make_tag tag (attrs,nodes) : node =

--- a/lib/ezxmlm.mli
+++ b/lib/ezxmlm.mli
@@ -50,11 +50,11 @@ val from_input : Xmlm.input -> Xmlm.dtd * node
 (** {2 Writing XML values } *)
 
 (** Write an XML document to an [out_channel] *)
-val to_channel : out_channel -> Xmlm.dtd -> nodes -> unit
+val to_channel : out_channel -> ?decl:bool -> Xmlm.dtd -> nodes -> unit
 
 (** Write an XML document to a [string].  This goes via an intermediate
     [Buffer] and so may be slow on large documents. *)
-val to_string : ?dtd:string -> nodes -> string
+val to_string : ?decl:bool -> ?dtd:string -> nodes -> string
 
 (** Low-level function to write directly to an [Xmlm] output source *)
 val to_output : Xmlm.output -> Xmlm.dtd * node -> unit


### PR DESCRIPTION
I'd like to write an XML document using `Ezxmlm` that includes the XML declaration. I've realized that `Ezxmlm` currently always passed `~decl:false` to `Xmlm.make_output`, so this PR adds an optional parameter to `Ezxmlm.to_string` and `Ezxmlm.to_channel` that allows one to set `decl` to `true`.
This optional parameter defaults to `false`, so this probably will not break existing code. I'm happy to change the way this is passed through to `Xmlm` in this PR, we only need a way of setting `decl` to `true`.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>